### PR TITLE
Added rrp_ip host variable to support redundant corosync rings setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ Role Variables
     cluster_net_iface: ''
     ```
 
+  - Redundant network interface. If specified the role will setup a corosync redundant ring using the default IPv4 from this interface.
+    Interface must exist on all cluster nodes.
+    ```
+      rrp_interface: ''
+    ```
+    NOTE: you can define this variable either in defaults/main.yml, in this case the same rrp_interface name is used for all hosts in the hosts file.
+          Either you specify an interface for each host present in the hosts file: this allows to use a specific interface name for each host (in the case they dont have the same interface name). Also note that instead of defining rrp_interface for a host, you can define rrp_ip: in this case this alternate ip is used to configure corosync RRP (this IP must be different than the host' default IPv4 address). This allows to use an alternate ip belonging to the same primary interface.
+
+
 Example Playbook
 ----------------
 
@@ -190,6 +199,9 @@ Inventory file example for CentOS/RHEL and Fedora systems.
     [cluster-rhel8]
     192.168.22.25 vm_name=fastvm-rhel-8.0-25 ansible_python_interpreter=/usr/libexec/platform-python
     192.168.22.26 vm_name=fastvm-rhel-8.0-26 ansible_python_interpreter=/usr/libexec/platform-python
+    [cluster-el-rrp]
+    192.168.22.27 vm_name=fastvm-centos-7.6-21 rrp_interface=ens6
+    192.168.22.28 vm_name=fastvm-centos-7.6-22 rrp_ip=192.168.22.29
 
 Video examples of running role with defaults for:
   - CentOS 7.6 installing CentOS 7.6 two node cluster: https://asciinema.org/a/226466

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,3 +86,7 @@ allow_cluster_expansion: false
 # By default the IPv4 addresses from `ansible_default_ipv4` are used. For exmaple to use IPv4 addresses
 # from interface `ens8` use `cluster_net_iface: 'ens8'`. Interface must exists on all cluster nodes.
 cluster_net_iface: ''
+
+#Redundant network interface. If specified the role will setup a corosync redundant ring using the default IPv4 from this interface.
+#Interface must exist on all cluster nodes.
+rrp_interface: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,9 +98,19 @@
     password: "{{ cluster_user_pass }}"
   with_items: "{{ play_hosts }}"
 
+- name: set corosync redundant ring node ip if requested
+  set_fact:
+    rrp_ip: "{{ hostvars[inventory_hostname]['ansible_'+rrp_interface].ipv4.address }}"
+  when: rrp_ip is not defined and rrp_interface is defined and rrp_interface and 'ansible_'+rrp_interface in hostvars[inventory_hostname]
+
+- name: validate redundant ring ip
+  fail:
+    msg: "invalid redundant ip {{ rrp_ip }} for {{ node inventory_hostname }}: must be different than default ip {{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}"
+  when: rrp_ip is defined and rrp_ip == ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0])
+ 
 - name: Setup cluster
   pcs_cluster:
-    node_list: "{% for item in play_hosts %}{{ hostvars[item]['ansible_hostname'] }} {% endfor %}"
+    node_list: "{% for item in play_hosts %}{{ hostvars[item]['ansible_hostname'] }}{% if hostvars[item].rrp_ip is defined %},{{ hostvars[item].rrp_ip }}{% endif %} {% endfor %}"
     cluster_name: "{{ cluster_name }}"
     transport: "{{ cluster_transport }}"
     allowed_node_changes: "{% if allow_cluster_expansion|bool %}add{% else %}none{% endif %}"


### PR DESCRIPTION
currently the role doesnt support redundant ring creation,
we fixed it by adding a rrp_ip host  variable in the play .hosts file for each node  e.g.: 
[all]
ip-172-31-1-9  rrp_ip=172.31.5.72 #must be valid ip, no name mapping is created in /etc/hosts file  
ip-172-31-1-197  rrp_ip=172.31.5.112

As you see In the hosts file, for each host/node defined, if a rrp_ip variable is defined (alternative ip for this node) a redundant ring will be created.
    (each node/host must have an alt ip defined)

maybe there is better way to do it, but i didnt see easy way