### PR TITLE
Add support for Pacemaker remote nodes, avoid /etc/hosts, customise hostname fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ Role Variables
   - Whether the node should be setup as a remote pacemaker node. By default
     this is `false`, and the node will be a full member of the Pacemaker
     cluster.  Pacemaker remote nodes are not full members of the cluster, and
-    allow exceeding the maximum cluster size of 32 full members.
+    allow exceeding the maximum cluster size of 32 full members. Note that
+    remote nodes are supported by this role only on EL7 and EL8.
 
     ```
     cluster_is_remote: false

--- a/README.md
+++ b/README.md
@@ -237,10 +237,9 @@ Inventory file example for CentOS/RHEL and Fedora systems.
 
 Inventory file example with two full members and two remote nodes:
 
-    [cluster-full]
+    [cluster]
     192.168.22.21 vm_name=fastvm-centos-7.6-21
     192.168.22.22 vm_name=fastvm-centos-7.6-22
-    [cluster-remote]
     192.168.22.23 vm_name=fastvm-centos-7.6-23 cluster_is_remote=True
     192.168.22.24 vm_name=fastvm-centos-7.6-24 cluster_is_remote=True
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Role Variables
     remote nodes are supported by this role only on EL7 and EL8.
 
     ```
-    cluster_is_remote: false
+    cluster_node_is_remote: false
     ```
 
 Example Playbook
@@ -241,8 +241,8 @@ Inventory file example with two full members and two remote nodes:
     [cluster]
     192.168.22.21 vm_name=fastvm-centos-7.6-21
     192.168.22.22 vm_name=fastvm-centos-7.6-22
-    192.168.22.23 vm_name=fastvm-centos-7.6-23 cluster_is_remote=True
-    192.168.22.24 vm_name=fastvm-centos-7.6-24 cluster_is_remote=True
+    192.168.22.23 vm_name=fastvm-centos-7.6-23 cluster_node_is_remote=True
+    192.168.22.24 vm_name=fastvm-centos-7.6-24 cluster_node_is_remote=True
 
 Video examples of running role with defaults for:
   - CentOS 7.6 installing CentOS 7.6 two node cluster: https://asciinema.org/a/226466

--- a/README.md
+++ b/README.md
@@ -162,6 +162,32 @@ Role Variables
           Either you specify an interface for each host present in the hosts file: this allows to use a specific interface name for each host (in the case they dont have the same interface name). Also note that instead of defining rrp_interface for a host, you can define rrp_ip: in this case this alternate ip is used to configure corosync RRP (this IP must be different than the host' default IPv4 address). This allows to use an alternate ip belonging to the same primary interface.
 
 
+  - Whether to add hosts to /etc/hosts. By default an entry for the hostname
+    given by `cluster_hostname_fact` is added for each host to `/etc/hosts`.
+    This can be disabled by setting `cluster_etc_hosts` to `false`.
+
+    ```
+    cluster_etc_hosts: true
+    ```
+
+  - Which Ansible fact to use as the hostname of cluster nodes. By default this
+    role uses the `ansible_hostname` fact as the hostname for each host. In
+    some environments it may be useful to use the Fully Qualified Domain Name
+    (FQDN) `ansible_fqdn` or node name `ansible_nodename`.
+
+    ```
+    cluster_hostname_fact: "ansible_hostname"
+    ```
+
+  - Whether the node should be setup as a remote pacemaker node. By default
+    this is `false`, and the node will be a full member of the Pacemaker
+    cluster.  Pacemaker remote nodes are not full members of the cluster, and
+    allow exceeding the maximum cluster size of 32 full members.
+
+    ```
+    cluster_is_remote: false
+    ```
+
 Example Playbook
 ----------------
 
@@ -188,6 +214,12 @@ Example playbook for creating cluster named 'vmware-cluster' with fence_vmware_s
       roles:
          - { role: 'ondrejhome.ha-cluster-pacemaker', cluster_name: 'vmware-cluster', cluster_configure_fence_xvm: false, cluster_configure_fence_vmware_soap: true }
 
+Example playbook for creating cluster named 'test-cluster' where `/etc/hosts` is not modified:
+
+    - hosts: servers
+      roles:
+         - { role: 'ondrejhome.ha-cluster-pacemaker', cluster_name: 'test-cluster', cluster_etc_hosts: false }
+
 Inventory file example for CentOS/RHEL and Fedora systems.
 
     [cluster-el]
@@ -202,6 +234,15 @@ Inventory file example for CentOS/RHEL and Fedora systems.
     [cluster-el-rrp]
     192.168.22.27 vm_name=fastvm-centos-7.6-21 rrp_interface=ens6
     192.168.22.28 vm_name=fastvm-centos-7.6-22 rrp_ip=192.168.22.29
+
+Inventory file example with two full members and two remote nodes:
+
+    [cluster-full]
+    192.168.22.21 vm_name=fastvm-centos-7.6-21
+    192.168.22.22 vm_name=fastvm-centos-7.6-22
+    [cluster-remote]
+    192.168.22.23 vm_name=fastvm-centos-7.6-23 cluster_is_remote=True
+    192.168.22.24 vm_name=fastvm-centos-7.6-24 cluster_is_remote=True
 
 Video examples of running role with defaults for:
   - CentOS 7.6 installing CentOS 7.6 two node cluster: https://asciinema.org/a/226466

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,3 +90,6 @@ cluster_net_iface: ''
 #Redundant network interface. If specified the role will setup a corosync redundant ring using the default IPv4 from this interface.
 #Interface must exist on all cluster nodes.
 rrp_interface: ''
+
+# Whether to add hosts to /etc/hosts.
+cluster_etc_hosts: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,3 +93,6 @@ rrp_interface: ''
 
 # Whether to add hosts to /etc/hosts.
 cluster_etc_hosts: true
+
+# Which Ansible fact to use as the hostname of cluster nodes.
+cluster_hostname_fact: "ansible_hostname"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -98,4 +98,4 @@ cluster_etc_hosts: true
 cluster_hostname_fact: "ansible_hostname"
 
 # Whether the node should be setup as a remote pacemaker node.
-cluster_is_remote: false
+cluster_node_is_remote: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,3 +96,6 @@ cluster_etc_hosts: true
 
 # Which Ansible fact to use as the hostname of cluster nodes.
 cluster_hostname_fact: "ansible_hostname"
+
+# Whether the node should be setup as a remote pacemaker node.
+cluster_is_remote: false

--- a/tasks/fence_kdump.yml
+++ b/tasks/fence_kdump.yml
@@ -7,17 +7,17 @@
 
 - name: create fence_kdump STONITH devices
   pcs_resource:
-    name: "fence-kdump-{{ hostvars[item]['ansible_fqdn'].split('.')[0] }}"
+    name: "fence-kdump-{{ hostvars[item][cluster_hostname_fact] }}"
     resource_class: 'stonith'
     resource_type: 'fence_kdump'
-    options: "pcmk_host_list={{ hostvars[item]['ansible_fqdn'].split('.')[0] }}"
+    options: "pcmk_host_list={{ hostvars[item][cluster_hostname_fact] }}"
   with_items: "{{ play_hosts }}"
   run_once: true
 
 - name: create fence constraints
   pcs_constraint_location:
-    resource: "fence-kdump-{{ hostvars[item]['ansible_fqdn'].split('.')[0] }}"
-    node_name: "{{ hostvars[item]['ansible_fqdn'].split('.')[0] }}"
+    resource: "fence-kdump-{{ hostvars[item][cluster_hostname_fact] }}"
+    node_name: "{{ hostvars[item][cluster_hostname_fact] }}"
     score: '-INFINITY'
   with_items: '{{ play_hosts }}'
   run_once: true

--- a/tasks/fence_vmware_soap.yml
+++ b/tasks/fence_vmware_soap.yml
@@ -26,11 +26,11 @@
 
 - name: create fence_vmware_soap STONITH devices
   pcs_resource:
-    name: "fence-{{ hostvars[item]['ansible_fqdn'].split('.')[0] }}"
+    name: "fence-{{ hostvars[item][cluster_hostname_fact] }}"
     resource_class: 'stonith'
     resource_type: 'fence_vmware_soap'
     options: >-
-      pcmk_host_map={{ hostvars[item]['ansible_fqdn'].split('.')[0] }}:{{ hostvars[item]['vm_name'] }};
+      pcmk_host_map={{ hostvars[item][cluster_hostname_fact] }}:{{ hostvars[item]['vm_name'] }};
       ipaddr={{ fence_vmware_ipaddr }}
       login={{ fence_vmware_login }}
       passwd={{ fence_vmware_passwd }}
@@ -40,8 +40,8 @@
 
 - name: create fence constraints
   pcs_constraint_location:
-    resource: "fence-{{ hostvars[item]['ansible_fqdn'].split('.')[0] }}"
-    node_name: "{{ hostvars[item]['ansible_fqdn'].split('.')[0] }}"
+    resource: "fence-{{ hostvars[item][cluster_hostname_fact] }}"
+    node_name: "{{ hostvars[item][cluster_hostname_fact] }}"
     score: '-INFINITY'
   with_items: "{{ play_hosts }}"
   run_once: true

--- a/tasks/fence_xvm.yml
+++ b/tasks/fence_xvm.yml
@@ -29,19 +29,19 @@
 
 - name: create fence_xvm STONITH devices
   pcs_resource:
-    name: "fence-{{ hostvars[item]['ansible_fqdn'].split('.')[0] }}"
+    name: "fence-{{ hostvars[item][cluster_hostname_fact] }}"
     resource_class: 'stonith'
     resource_type: 'fence_xvm'
     options: >-
-      pcmk_host_map={{ hostvars[item]['ansible_fqdn'].split('.')[0] }}:{{ hostvars[item]['vm_name'] }};
+      pcmk_host_map={{ hostvars[item][cluster_hostname_fact] }}:{{ hostvars[item]['vm_name'] }};
       op monitor interval=30s
   with_items: "{{ play_hosts }}"
   run_once: true
 
 - name: create fence constraints
   pcs_constraint_location:
-    resource: "fence-{{ hostvars[item]['ansible_fqdn'].split('.')[0] }}"
-    node_name: "{{ hostvars[item]['ansible_fqdn'].split('.')[0] }}"
+    resource: "fence-{{ hostvars[item][cluster_hostname_fact] }}"
+    node_name: "{{ hostvars[item][cluster_hostname_fact] }}"
     score: '-INFINITY'
   with_items: "{{ play_hosts }}"
   run_once: true

--- a/tasks/install_normal.yml
+++ b/tasks/install_normal.yml
@@ -7,7 +7,7 @@
 
 - name: Install Pacemaker cluster packages to all nodes
   yum:
-    name: "{{ cluster_is_remote | bool | ternary(pacemaker_remote_packages, pacemaker_packages) }}"
+    name: "{{ cluster_node_is_remote | bool | ternary(pacemaker_remote_packages, pacemaker_packages) }}"
     state: 'installed'
 
 - name: Install firewall packages

--- a/tasks/install_normal.yml
+++ b/tasks/install_normal.yml
@@ -7,7 +7,7 @@
 
 - name: Install Pacemaker cluster packages to all nodes
   yum:
-    name: "{{ pacemaker_packages }}"
+    name: "{{ cluster_is_remote | bool | ternary(pacemaker_remote_packages, pacemaker_packages) }}"
     state: 'installed'
 
 - name: Install firewall packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
+- name: Add a group to the inventory for remote nodes
+  group_by:
+    key: "cluster_is_remote_{{ cluster_is_remote | bool }}"
+
 - name: Check if cluster consist of at least 2 nodes
   fail:
-    msg: 'Cluster must have at least 2 members'
-  when: play_hosts|count() < 2
+    msg: 'Cluster must have at least 2 full members'
+  when: groups['cluster_is_remote_False']|default([])|count() < 2
   run_once: true
 
 - name: Include distribution version specific variables - RHEL/CentOS
@@ -102,10 +106,6 @@
   with_items: "{{ play_hosts }}"
   when: not cluster_is_remote | bool
 
-- name: Set a fact about whether the node is remote
-  set_fact:
-    cluster_is_remote: "{{ cluster_is_remote | bool }}"
-
 - name: set corosync redundant ring node ip if requested
   set_fact:
     rrp_ip: "{{ hostvars[inventory_hostname]['ansible_'+rrp_interface].ipv4.address }}"
@@ -118,7 +118,7 @@
  
 - name: Setup cluster
   pcs_cluster:
-    node_list: "{% for item in play_hosts %}{{ hostvars[item][cluster_hostname_fact] }}{% if hostvars[item].rrp_ip is defined %},{{ hostvars[item].rrp_ip }}{% endif %} {% endfor %}"
+    node_list: "{% for item in groups['cluster_is_remote_False'] %}{{ hostvars[item][cluster_hostname_fact] }}{% if hostvars[item].rrp_ip is defined %},{{ hostvars[item].rrp_ip }}{% endif %} {% endfor %}"
     cluster_name: "{{ cluster_name }}"
     transport: "{{ cluster_transport }}"
     allowed_node_changes: "{% if allow_cluster_expansion|bool %}add{% else %}none{% endif %}"
@@ -131,6 +131,7 @@
   with_items:
     - pacemaker
     - corosync
+  when: not cluster_is_remote | bool
 
 - name: Enable cluster services on boot
   service:
@@ -140,6 +141,26 @@
   with_items:
     - pacemaker
     - corosync
+  when: not cluster_is_remote | bool
+
+- name: Get cluster status
+  command: pcs cluster status
+  run_once: true
+  changed_when: false
+  register: cluster_status
+
+- name: Add remote node
+  vars:
+    cluster_hostname: "{{ hostvars[inventory_hostname][cluster_hostname_fact] }}"
+    delegate_host: "{{ hostvars[groups['cluster_is_remote_False'][0]].inventory_hostname }}"
+    # NOTE: Without this, the host's ansible_host variable will not be
+    # respected when using delegate_to.
+    ansible_host: "{{ hostvars[delegate_host].ansible_host | default(delegate_host) }}"
+  command: pcs cluster node add-remote {{ cluster_hostname }}
+  when:
+    - cluster_hostname not in (cluster_status.stdout | regex_search('RemoteOnline.*') or '')
+    - cluster_is_remote | bool
+  delegate_to: "{{ delegate_host }}"
 
 ### fencing setup
 - name: Setup automatic fence_xvm

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,9 @@
       {{ hostvars[item]['ansible_default_ipv4']['address'] }}
       {{ hostvars[item]['ansible_fqdn'].split('.')[0] }}
   with_items: "{{ play_hosts }}"
-  when: hostvars[item]['ansible_'+cluster_net_iface] is not defined
+  when:
+    - cluster_etc_hosts | bool
+    - hostvars[item]['ansible_'+cluster_net_iface] is not defined
 
 - name: Add hosts to /etc/hosts (using alternative interface)
   lineinfile:
@@ -50,7 +52,9 @@
       {{ hostvars[item]['ansible_'+cluster_net_iface]['ipv4']['address'] }}
       {{ hostvars[item]['ansible_fqdn'].split('.')[0] }}
   with_items: "{{ play_hosts }}"
-  when: hostvars[item]['ansible_'+cluster_net_iface] is defined
+  when:
+    - cluster_etc_hosts | bool
+    - hostvars[item]['ansible_'+cluster_net_iface] is defined
 
 - name: Create cluster system group
   group:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -142,24 +142,28 @@
     - corosync
   when: not cluster_node_is_remote | bool
 
-- name: Get cluster status
-  command: pcs cluster status
-  run_once: true
-  changed_when: false
-  check_mode: false
-  register: cluster_status
+- block:
+    - name: Get pcs status
+      command: pcs status
+      run_once: true
+      changed_when: false
+      check_mode: false
+      register: pcs_status
 
-- name: Add remote node
+    - name: Add remote node
+      vars:
+        cluster_hostname: "{{ hostvars[inventory_hostname][cluster_hostname_fact] }}"
+      command: pcs cluster node add-remote {{ cluster_hostname }}
+      when:
+        - cluster_node_is_remote | bool
+        - (pcs_status.stdout | regex_search('\\b' ~ cluster_hostname ~ '\\s+\\(ocf::pacemaker:remote\\)') or '') | length == 0
   vars:
-    cluster_hostname: "{{ hostvars[inventory_hostname][cluster_hostname_fact] }}"
     delegate_host: "{{ hostvars[groups['cluster_node_is_remote_False'][0]].inventory_hostname }}"
     # NOTE: Without this, the host's ansible_host variable will not be
     # respected when using delegate_to.
     ansible_host: "{{ hostvars[delegate_host].ansible_host | default(delegate_host) }}"
-  command: pcs cluster node add-remote {{ cluster_hostname }}
   when:
-    - cluster_hostname not in (cluster_status.stdout | regex_search('RemoteOnline.*') or '')
-    - cluster_node_is_remote | bool
+    - groups['cluster_node_is_remote_False'] is defined
   delegate_to: "{{ delegate_host }}"
 
 ### fencing setup

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Add a group to the inventory for remote nodes
   group_by:
-    key: "cluster_is_remote_{{ cluster_is_remote | bool }}"
+    key: "cluster_node_is_remote_{{ cluster_node_is_remote | bool }}"
 
 - name: Check if cluster consist of at least 2 nodes
   fail:
     msg: 'Cluster must have at least 2 full members'
-  when: groups['cluster_is_remote_False']|default([])|count() < 2
+  when: groups['cluster_node_is_remote_False']|default([])|count() < 2
   run_once: true
 
 - name: Include distribution version specific variables - RHEL/CentOS
@@ -104,7 +104,7 @@
     username: "{{ cluster_user }}"
     password: "{{ cluster_user_pass }}"
   with_items: "{{ play_hosts }}"
-  when: not cluster_is_remote | bool
+  when: not cluster_node_is_remote | bool
 
 - name: set corosync redundant ring node ip if requested
   set_fact:
@@ -118,7 +118,7 @@
  
 - name: Setup cluster
   pcs_cluster:
-    node_list: "{% for item in groups['cluster_is_remote_False'] %}{{ hostvars[item][cluster_hostname_fact] }}{% if hostvars[item].rrp_ip is defined %},{{ hostvars[item].rrp_ip }}{% endif %} {% endfor %}"
+    node_list: "{% for item in groups['cluster_node_is_remote_False'] %}{{ hostvars[item][cluster_hostname_fact] }}{% if hostvars[item].rrp_ip is defined %},{{ hostvars[item].rrp_ip }}{% endif %} {% endfor %}"
     cluster_name: "{{ cluster_name }}"
     transport: "{{ cluster_transport }}"
     allowed_node_changes: "{% if allow_cluster_expansion|bool %}add{% else %}none{% endif %}"
@@ -131,7 +131,7 @@
   with_items:
     - pacemaker
     - corosync
-  when: not cluster_is_remote | bool
+  when: not cluster_node_is_remote | bool
 
 - name: Enable cluster services on boot
   service:
@@ -140,7 +140,7 @@
   with_items:
     - pacemaker
     - corosync
-  when: not cluster_is_remote | bool
+  when: not cluster_node_is_remote | bool
 
 - name: Get cluster status
   command: pcs cluster status
@@ -151,14 +151,14 @@
 - name: Add remote node
   vars:
     cluster_hostname: "{{ hostvars[inventory_hostname][cluster_hostname_fact] }}"
-    delegate_host: "{{ hostvars[groups['cluster_is_remote_False'][0]].inventory_hostname }}"
+    delegate_host: "{{ hostvars[groups['cluster_node_is_remote_False'][0]].inventory_hostname }}"
     # NOTE: Without this, the host's ansible_host variable will not be
     # respected when using delegate_to.
     ansible_host: "{{ hostvars[delegate_host].ansible_host | default(delegate_host) }}"
   command: pcs cluster node add-remote {{ cluster_hostname }}
   when:
     - cluster_hostname not in (cluster_status.stdout | regex_search('RemoteOnline.*') or '')
-    - cluster_is_remote | bool
+    - cluster_node_is_remote | bool
   delegate_to: "{{ delegate_host }}"
 
 ### fencing setup

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -146,6 +146,7 @@
   command: pcs cluster status
   run_once: true
   changed_when: false
+  check_mode: false
   register: cluster_status
 
 - name: Add remote node

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -137,7 +137,6 @@
   service:
     name: "{{ item }}"
     enabled: true
-  when: cluster_enable_service|bool
   with_items:
     - pacemaker
     - corosync

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,8 +29,7 @@
   include_tasks: install_normal.yml
   when: not use_local_media|bool
 
-# TODO allow to choose if to use FQDN or just short hostname, defaulting to short hostname
-# WARNING: the 'ansible_fqdn' is resolved from /etc/hosts file! If you change hostname
+# WARNING: the hostname is resolved from /etc/hosts file! If you change hostname
 # of machine through /etc/hosts the ansible will pick it up and use it!
 - name: Add hosts to /etc/hosts (using default (GW) IPv4 address)
   lineinfile:
@@ -38,7 +37,7 @@
     regexp: "{{ hostvars[item]['ansible_default_ipv4']['address'] }} "
     line: >
       {{ hostvars[item]['ansible_default_ipv4']['address'] }}
-      {{ hostvars[item]['ansible_fqdn'].split('.')[0] }}
+      {{ hostvars[item][cluster_hostname_fact] }}
   with_items: "{{ play_hosts }}"
   when:
     - cluster_etc_hosts | bool
@@ -50,7 +49,7 @@
     regexp: "{{ hostvars[item]['ansible_'+cluster_net_iface]['ipv4']['address'] }} "
     line: >
       {{ hostvars[item]['ansible_'+cluster_net_iface]['ipv4']['address'] }}
-      {{ hostvars[item]['ansible_fqdn'].split('.')[0] }}
+      {{ hostvars[item][cluster_hostname_fact] }}
   with_items: "{{ play_hosts }}"
   when:
     - cluster_etc_hosts | bool
@@ -97,10 +96,15 @@
 
 - name: Authorize cluster nodes
   pcs_auth:
-    node_name: "{{ hostvars[item]['ansible_fqdn'].split('.')[0] }}"
+    node_name: "{{ hostvars[item][cluster_hostname_fact] }}"
     username: "{{ cluster_user }}"
     password: "{{ cluster_user_pass }}"
   with_items: "{{ play_hosts }}"
+  when: not cluster_is_remote | bool
+
+- name: Set a fact about whether the node is remote
+  set_fact:
+    cluster_is_remote: "{{ cluster_is_remote | bool }}"
 
 - name: set corosync redundant ring node ip if requested
   set_fact:
@@ -114,7 +118,7 @@
  
 - name: Setup cluster
   pcs_cluster:
-    node_list: "{% for item in play_hosts %}{{ hostvars[item]['ansible_hostname'] }}{% if hostvars[item].rrp_ip is defined %},{{ hostvars[item].rrp_ip }}{% endif %} {% endfor %}"
+    node_list: "{% for item in play_hosts %}{{ hostvars[item][cluster_hostname_fact] }}{% if hostvars[item].rrp_ip is defined %},{{ hostvars[item].rrp_ip }}{% endif %} {% endfor %}"
     cluster_name: "{{ cluster_name }}"
     transport: "{{ cluster_transport }}"
     allowed_node_changes: "{% if allow_cluster_expansion|bool %}add{% else %}none{% endif %}"

--- a/vars/el6.yml
+++ b/vars/el6.yml
@@ -3,6 +3,9 @@ pacemaker_packages:
  - pcs
  - pacemaker
  - cman
+pacemaker_remote_packages:
+ - pcs
+ - pacemaker-remote
 fence_xvm_packages:
  - fence-virt
 fence_kdump_packages:

--- a/vars/el7.yml
+++ b/vars/el7.yml
@@ -2,6 +2,9 @@
 pacemaker_packages:
  - pcs
  - pacemaker
+pacemaker_remote_packages:
+ - pcs
+ - pacemaker-remote
 fence_xvm_packages:
  - fence-virt
 fence_kdump_packages:

--- a/vars/el8.yml
+++ b/vars/el8.yml
@@ -3,6 +3,9 @@ pacemaker_packages:
  - pcs
  - pacemaker
  - libknet1-crypto-nss-plugin
+pacemaker_remote_packages:
+ - pcs
+ - pacemaker-remote
 fence_xvm_packages:
  - fence-virt
 fence_kdump_packages:

--- a/vars/fedora28.yml
+++ b/vars/fedora28.yml
@@ -2,6 +2,9 @@
 pacemaker_packages:
  - pcs
  - pacemaker
+pacemaker_remote_packages:
+ - pcs
+ - pacemaker-remote
 fence_xvm_packages:
  - fence-virt
 fence_kdump_packages:

--- a/vars/fedora29.yml
+++ b/vars/fedora29.yml
@@ -2,6 +2,9 @@
 pacemaker_packages:
  - pcs
  - pacemaker
+pacemaker_remote_packages:
+ - pcs
+ - pacemaker-remote
 fence_xvm_packages:
  - fence-virt
 fence_kdump_packages:

--- a/vars/fedora30.yml
+++ b/vars/fedora30.yml
@@ -2,6 +2,9 @@
 pacemaker_packages:
  - pcs
  - pacemaker
+pacemaker_remote_packages:
+ - pcs
+ - pacemaker-remote
 fence_xvm_packages:
  - fence-virt
 fence_kdump_packages:


### PR DESCRIPTION
* Add support for remote nodes
    
  Remote nodes do not run corosync or the full pacemaker stack, and allow scaling clusters beyond the 32 node limit for full cluster members.

* Allow customisation of which fact is used for hostnames

  Previously, this role used the host part of ansible_fqdn. This should be the same as ansible_hostname. In some cases we may wish to use the full FQDN, or the nodename (ansible_nodename). This change adds support for modifying the fact used via a cluster_hostname_fact variable, which defaults to ansible_hostname.

* Allow skipping update of /etc/hosts

  In some cases we may already have /etc/hosts populated through some other means, or wish to use DNS for name resolution.