### PR TITLE
Fixed CentOS stream HA repo

### DIFF
--- a/tasks/centos_repos.yml
+++ b/tasks/centos_repos.yml
@@ -21,8 +21,24 @@
     and ansible_distribution_version in ['8.1', '8.2']
 
 - name: enable highavailability repository (CentOS 8.3+)
+  ignore_errors: yes
   ini_file:
     dest: '/etc/yum.repos.d/CentOS-Linux-HighAvailability.repo'
+    section: 'ha'
+    option: 'enabled'
+    value: '1'
+    create: 'no'
+    mode: '0644'
+  when: >-
+    'HighAvailability' not in yum_repolist.stdout
+    and enable_repos | bool
+    and ansible_distribution_major_version in ['8']
+    and ansible_distribution_version not in ['8.0', '8.1', '8.2']
+
+- name: enable highavailability repository (CentOS 8 Stream)
+  ignore_errors: yes
+  ini_file:
+    dest: '/etc/yum.repos.d/CentOS-Stream-HighAvailability.repo'
     section: 'ha'
     option: 'enabled'
     value: '1'

--- a/tasks/centos_repos.yml
+++ b/tasks/centos_repos.yml
@@ -21,7 +21,6 @@
     and ansible_distribution_version in ['8.1', '8.2']
 
 - name: enable highavailability repository (CentOS 8.3+)
-  ignore_errors: yes
   ini_file:
     dest: '/etc/yum.repos.d/CentOS-Linux-HighAvailability.repo'
     section: 'ha'
@@ -33,10 +32,9 @@
     'HighAvailability' not in yum_repolist.stdout
     and enable_repos | bool
     and ansible_distribution_major_version in ['8']
-    and ansible_distribution_version not in ['8.0', '8.1', '8.2']
+    and ansible_distribution_version not in ['8.0', '8.1', '8.2', '8']
 
 - name: enable highavailability repository (CentOS 8 Stream)
-  ignore_errors: yes
   ini_file:
     dest: '/etc/yum.repos.d/CentOS-Stream-HighAvailability.repo'
     section: 'ha'
@@ -48,4 +46,4 @@
     'HighAvailability' not in yum_repolist.stdout
     and enable_repos | bool
     and ansible_distribution_major_version in ['8']
-    and ansible_distribution_version not in ['8.0', '8.1', '8.2']
+    and ansible_distribution_version not in ['8.0', '8.1', '8.2', '8.3']


### PR DESCRIPTION
I tried this role out on centos 8 stream and it didn't modify the High Availability repo's properly.

I have tested this role and it behaves as expected.

I had to use ignore_errors because unfortunately ansible cannot distinguish centos 8 from centos stream.

If there is a better way to do it then I will obviously try to correct this.