### PR TITLE
Remove unsecure default password

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,11 @@ Role Variables
         score: optional
     ```
 
+Security considerations
+-----------------------
+
+Please consider updating the default value for `cluster_user_pass`.
+
 Example Playbook
 ----------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,14 @@
   when: groups['cluster_node_is_remote_False']|default([])|count() < 2
   run_once: true
 
+- name: Check if cluster_user_pass is not default
+  assert:
+    that:
+      - cluster_user_pass != 'testtest'
+    fail_msg: 'It is strongly recommended to define a password'
+  ignore_errors: true
+  run_once: true
+
 - name: Include distribution version specific variables - RHEL/CentOS
   include_vars: "el{{ ansible_distribution_major_version }}.yml"
   when: ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'


### PR DESCRIPTION
Providing default passwords in a role is a bad idea in my opinion, most of the time users won't read the README or defaults/main and the insecure value will be kept.

What do you think?