### PR TITLE
Allow to disable PCSD GUI on Debian

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,7 +85,7 @@
 
 - name: Enable/Disable PCSD web GUI
   lineinfile:
-    dest: '/etc/sysconfig/pcsd'
+    dest: "{{ pcsd_configuration_file }}"
     regexp: 'PCSD_DISABLE_GUI=.*'
     line: "PCSD_DISABLE_GUI={{ enable_pcsd_gui|bool|ternary('false','true') }}"
     mode: '0644'

--- a/vars/debian10.yml
+++ b/vars/debian10.yml
@@ -8,3 +8,5 @@ pacemaker_remote_packages:
 
 cluster_configure_fence_xvm: false
 cluster_firewall: false
+
+pcsd_configuration_file: /etc/default/pcsd

--- a/vars/fedora31.yml
+++ b/vars/fedora31.yml
@@ -17,3 +17,5 @@ fence_vmware_rest_packages:
  - fence-agents-vmware-rest
 firewall_packages:
  - firewalld
+
+pcsd_configuration_file: /etc/sysconfig/pcsd

--- a/vars/fedora32.yml
+++ b/vars/fedora32.yml
@@ -17,3 +17,5 @@ fence_vmware_rest_packages:
  - fence-agents-vmware-rest
 firewall_packages:
  - firewalld
+
+pcsd_configuration_file: /etc/sysconfig/pcsd

--- a/vars/fedora33.yml
+++ b/vars/fedora33.yml
@@ -17,3 +17,5 @@ fence_vmware_rest_packages:
  - fence-agents-vmware-rest
 firewall_packages:
  - firewalld
+
+pcsd_configuration_file: /etc/sysconfig/pcsd

--- a/vars/redhat6.yml
+++ b/vars/redhat6.yml
@@ -15,3 +15,5 @@ fence_vmware_soap_packages:
  - fence-agents
 firewall_packages:
  - iptables
+
+pcsd_configuration_file: /etc/sysconfig/pcsd

--- a/vars/redhat7.yml
+++ b/vars/redhat7.yml
@@ -16,3 +16,5 @@ fence_vmware_rest_packages:
  - fence-agents-vmware-rest
 firewall_packages:
  - firewalld
+
+pcsd_configuration_file: /etc/sysconfig/pcsd

--- a/vars/redhat8.yml
+++ b/vars/redhat8.yml
@@ -17,3 +17,5 @@ fence_vmware_rest_packages:
  - fence-agents-vmware-rest
 firewall_packages:
  - firewalld
+
+pcsd_configuration_file: /etc/sysconfig/pcsd


### PR DESCRIPTION
I am not sure about the variable name but the diff allows to disable PCSD GUI on Debian just like on the other supported operating systems. This new variable is not supposed to be modified by users so I did not document it in the README, hope it makes sense.