### PR TITLE
Fix issue on Centos 8.4 when enabling centos HA repository

### DIFF
--- a/tasks/centos_repos.yml
+++ b/tasks/centos_repos.yml
@@ -46,4 +46,4 @@
     'HighAvailability' not in yum_repolist.stdout
     and enable_repos | bool
     and ansible_distribution_major_version in ['8']
-    and ansible_distribution_version not in ['8.0', '8.1', '8.2', '8.3']
+    and ansible_distribution_version not in ['8.0', '8.1', '8.2', '8.3', '8.4']


### PR DESCRIPTION
On Centos 8.4 (which is the latest as Centos 8 is being discontinued), the centos_repo task fails because of missing minor version in the when condition when enabling HA repo,
(ansible book plays ok on  Centos 8.4, however i didnt test all features (rrp for example)), 