### PR TITLE
add support for Rocky Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ha-cluster-pacemaker
 =========
 
-Role for configuring and expanding basic pacemaker cluster on CentOS/RHEL 6/7/8, AlmaLinux 8, Fedora 31/32/33 and CentOS 8 Stream systems.
+Role for configuring and expanding basic pacemaker cluster on CentOS/RHEL 6/7/8, AlmaLinux 8, Rocky Linux 8, Fedora 31/32/33 and CentOS 8 Stream systems.
 
 This role can configure following aspects of pacemaker cluster:
 - enable needed system repositories
@@ -131,7 +131,7 @@ Role Variables
     cluster_configure_stonith_style: 'one-device-per-node'
     ```
 
-  - (RHEL/CentOS/AlmaLinux) enable the repositories containing needed packages
+  - (RHEL/CentOS/AlmaLinux/Rocky) enable the repositories containing needed packages
     ```
     enable_repos: true
     ```

--- a/tasks/install_normal.yml
+++ b/tasks/install_normal.yml
@@ -4,7 +4,7 @@
     name: 'libselinux-python'
     state: 'installed'
   when:
-    - not (ansible_distribution in ['RedHat','CentOS','AlmaLinux'] and ansible_distribution_major_version == '8')
+    - not (ansible_distribution in ['RedHat','CentOS','AlmaLinux','Rocky'] and ansible_distribution_major_version == '8')
     - not (ansible_distribution == 'Fedora' and ansible_distribution_major_version >= '31')
 
 - name: Install Pacemaker cluster packages to all nodes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,11 +108,11 @@
     enabled: true
     state: 'started'
 
-- name: Setup firewall for RHEL/CentOS/AlmaLinux systems
+- name: Setup firewall for RHEL/CentOS/AlmaLinux/Rocky systems
   include_tasks: "firewall-el{{ ansible_distribution_major_version }}.yml"
   when:
     - cluster_firewall|bool
-    - ansible_distribution in ['RedHat','CentOS','AlmaLinux']
+    - ansible_distribution in ['RedHat','CentOS','AlmaLinux','Rocky']
 
 - name: Setup firewall for Fedora systems
   include_tasks: "firewall-fedora.yml"

--- a/tasks/rocky_repos.yml
+++ b/tasks/rocky_repos.yml
@@ -1,0 +1,21 @@
+---
+- name: get list of active repositories
+  command: yum repolist
+  args:
+    warn: false
+  register: yum_repolist
+  changed_when: false
+  check_mode: false
+
+- name: enable highavailability repository (Rocky)
+  ini_file:
+    dest: '/etc/yum.repos.d/Rocky-HighAvailability.repo'
+    section: 'ha'
+    option: 'enabled'
+    value: '1'
+    create: 'no'
+    mode: '0644'
+  when: >-
+    'HighAvailability' not in yum_repolist.stdout
+    and enable_repos | bool
+    and ansible_distribution_major_version in ['8']


### PR DESCRIPTION
Add support for Rocky Linux. No need for much logic in `rocky_repos.yml` because there was no release `<8.4`.  Strictly speaking the  `and ansible_distribution_major_version in ['8']` condition isn't even necessary but left it in for a future Rocky Linux 9. 