### PR TITLE
FIX Centos8 yum repos: Update mirror list in yum repos for Centos 8 d…

### DIFF
--- a/tasks/centos_repos.yml
+++ b/tasks/centos_repos.yml
@@ -1,4 +1,28 @@
 ---
+- set_fact:
+    yum_repofiles: "{{ lookup('fileglob', '/etc/yum.repos.d/CentOS-Linux-*', wantlist=True) }}"
+    centos_stream: "{{ 'false' if ansible_distribution_version in ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5'] else 'true' }}"
+
+- name: disable mirrorlist in all Centos 8 repositories
+  replace:
+      path: "{{ file }}"
+      regexp: "^mirrorlist"
+      replace: "#mirrorlist"
+  loop: "{{ yum_repofiles }}"
+  loop_control:
+    loop_var: file
+  when: not centos_stream and ansible_distribution_major_version in ['8']
+
+- name: update mirrror baseurl in all Centos 8 repositories
+  replace:
+      path: "{{ file }}"
+      regexp: "^#baseurl=http://mirror.centos.org"
+      replace: "baseurl=http://vault.centos.org"
+  loop: "{{ yum_repofiles }}"
+  loop_control:
+    loop_var: file
+  when: not centos_stream and ansible_distribution_major_version in ['8']
+
 - name: get list of active repositories
   command: yum repolist
   args:


### PR DESCRIPTION
…istros

(fix Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist errors since Centos8 is EOL)