### PR TITLE
fix: omit warn command argument for ansible > 2.14

### DIFF
--- a/tasks/almalinux_repos.yml
+++ b/tasks/almalinux_repos.yml
@@ -2,7 +2,7 @@
 - name: get list of active repositories
   command: yum repolist
   args:
-    warn: false
+    warn: "{{ (ansible_version.full is version('2.14','<')) | ternary(false, omit) }}"
   register: yum_repolist
   changed_when: false
   check_mode: false

--- a/tasks/centos_repos.yml
+++ b/tasks/centos_repos.yml
@@ -2,7 +2,7 @@
 - name: get list of active repositories
   command: yum repolist
   args:
-    warn: false
+    warn: "{{ (ansible_version.full is version('2.14','<')) | ternary(false, omit) }}"
   register: yum_repolist
   changed_when: false
   check_mode: false

--- a/tasks/redhat_repos.yml
+++ b/tasks/redhat_repos.yml
@@ -2,7 +2,7 @@
 - name: get list of active repositories
   command: yum repolist
   args:
-    warn: false
+    warn: "{{ (ansible_version.full is version('2.14','<')) | ternary(false, omit) }}"
   register: yum_repolist
   changed_when: false
   check_mode: false

--- a/tasks/rocky_repos.yml
+++ b/tasks/rocky_repos.yml
@@ -2,7 +2,7 @@
 - name: get list of active repositories
   command: yum repolist
   args:
-    warn: false
+    warn: "{{ (ansible_version.full is version('2.14','<')) | ternary(false, omit) }}"
   register: yum_repolist
   changed_when: false
   check_mode: false


### PR DESCRIPTION
Hello,

The command module should use the warn argument when ansible_version is < 2.14.
The deprecation notice is available here : https://github.com/ansible/ansible/pull/77411

This should fix #25.