### PR TITLE
Add support for Rocky 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ha-cluster-pacemaker
 =========
 
-Role for configuring and expanding basic pacemaker cluster on CentOS/RHEL 6/7/8/9, AlmaLinux 8/9, Rocky Linux 8, Fedora 31/32/33/34/35/36 and CentOS 8 Stream systems.
+Role for configuring and expanding basic pacemaker cluster on CentOS/RHEL 6/7/8/9, AlmaLinux 8/9, Rocky Linux 8/9, Fedora 31/32/33/34/35/36 and CentOS 8 Stream systems.
 
 This role can configure following aspects of pacemaker cluster:
 - enable needed system repositories
@@ -48,7 +48,7 @@ Ansible version **2.9.10** and **2.9.11** will fail with error `"'hostvars' is u
 
 On **CentOS Linux 8** you have to ensure that BaseOS and Appstream repositories are working properly. As the CentOS Linux 8 is in the End-Of-Life phase, this role will configure HA repository to point to vault.centos.org if repository configuration (`enable_repos: true`) is requested (it is by default).
 
-**pcs-0.11** version distributions (AlmaLinux 9, RHEL 9, Fedora 36) are supported only with ondrejhome.pcs-modules-2 version 27.0.0 or higher.
+**pcs-0.11** version distributions (AlmaLinux 9, Rocky Linux 9, RHEL 9, Fedora 36) are supported only with ondrejhome.pcs-modules-2 version 27.0.0 or higher.
 
 Role Variables
 --------------

--- a/tasks/install_normal.yml
+++ b/tasks/install_normal.yml
@@ -5,7 +5,7 @@
     state: 'installed'
   when:
     - not (ansible_distribution in ['RedHat','CentOS','AlmaLinux','Rocky'] and ansible_distribution_major_version == '8')
-    - not (ansible_distribution in ['RedHat','AlmaLinux'] and ansible_distribution_major_version == '9')
+    - not (ansible_distribution in ['RedHat','AlmaLinux','Rocky'] and ansible_distribution_major_version == '9')
     - not (ansible_distribution == 'Fedora' and ansible_distribution_major_version >= '31')
 
 - name: Install Pacemaker cluster packages to all nodes

--- a/tasks/rocky_repos.yml
+++ b/tasks/rocky_repos.yml
@@ -7,7 +7,7 @@
   changed_when: false
   check_mode: false
 
-- name: enable highavailability repository (Rocky)
+- name: enable highavailability repository (Rocky 8)
   ini_file:
     dest: '/etc/yum.repos.d/Rocky-HighAvailability.repo'
     section: 'ha'
@@ -19,3 +19,16 @@
     'HighAvailability' not in yum_repolist.stdout
     and enable_repos | bool
     and ansible_distribution_major_version in ['8']
+
+- name: enable highavailability repository (Rocky 9)
+  ini_file:
+    dest: '/etc/yum.repos.d/rocky-addons.repo'
+    section: 'highavailability'
+    option: 'enabled'
+    value: '1'
+    create: 'no'
+    mode: '0644'
+  when: >-
+    'highavailability' not in yum_repolist.stdout
+    and enable_repos | bool
+    and ansible_distribution_major_version in ['9']


### PR DESCRIPTION
I made these changes by hand when trying this role out on Rocky 9 and then I realized that my changes were essentially the same as the ones [in this older commit enabling RHEL9/AlmaLinux9 ](https://github.com/OndrejHome/ansible.ha-cluster-pacemaker/commit/498223774c9da9fc0d1da5af726ed2046071ac13)for AlmaLinux, i figured i should open a PR