### PR TITLE
Install pacemaker-cli-utils on Debian

### DIFF
--- a/vars/debian10.yml
+++ b/vars/debian10.yml
@@ -2,9 +2,11 @@
 pacemaker_packages:
  - pcs
  - pacemaker
+ - pacemaker-cli-utils
 pacemaker_remote_packages:
  - pcs
  - pacemaker-remote
+ - pacemaker-cli-utils
 fence_kdump_packages:
  - kdump-tools
 

--- a/vars/debian11.yml
+++ b/vars/debian11.yml
@@ -2,9 +2,11 @@
 pacemaker_packages:
  - pcs
  - pacemaker
+ - pacemaker-cli-utils
 pacemaker_remote_packages:
  - pcs
  - pacemaker-remote
+ - pacemaker-cli-utils
 fence_kdump_packages:
  - kdump-tools
 

--- a/vars/debian12.yml
+++ b/vars/debian12.yml
@@ -2,9 +2,11 @@
 pacemaker_packages:
  - pcs
  - pacemaker
+ - pacemaker-cli-utils
 pacemaker_remote_packages:
  - pcs
  - pacemaker-remote
+ - pacemaker-cli-utils
 fence_kdump_packages:
  - kdump-tools
 


### PR DESCRIPTION
This installs /usr/sbin/crm_mon which is required for "pcs status"