### PR TITLE
fix: add missing `centos8.yml` vars file

### DIFF
--- a/vars/centos8.yml
+++ b/vars/centos8.yml
@@ -1,0 +1,23 @@
+---
+pacemaker_packages:
+ - pcs
+ - pacemaker
+ - libknet1-crypto-nss-plugin
+pacemaker_remote_packages:
+ - pcs
+ - pacemaker-remote
+fence_xvm_packages:
+ - fence-virt
+fence_kdump_packages:
+ - fence-agents-kdump
+ - kexec-tools
+fence_vmware_soap_packages:
+ - fence-agents-vmware-soap
+fence_vmware_rest_packages:
+ - fence-agents-vmware-rest
+fence_aws_packages:
+ - fence-agents-aws
+firewall_packages:
+ - firewalld
+
+pcsd_configuration_file: /etc/sysconfig/pcsd


### PR DESCRIPTION
It appears that Ansible has changed how it identifies Centos 8 Stream and whilst this worked without issue in the past newer versions of Ansible fail to find a suitable variable file during the the task `Include distribution version specific variables`

Fixed: #34