### PR TITLE
Add support for rules in location constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,10 +329,22 @@ Role Variables
 
   - Configure cluster location constraints (Not mandatory)
 
+    **node based**
+
     ```
     cluster_constraint_location:
       - resource: required
         node_name: required
+        score: optional
+    ```
+
+    **rule based**
+
+    ```
+    cluster_constraint_location:
+      - resource: required
+        constraint_id: required
+        rule: required
         score: optional
     ```
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Role Variables
         score: optional
     ```
 
-    **rule based**
+    **rule based** (_needs ondrejhome.pcs-modules-2 v30 or newer_)
 
     ```
     cluster_constraint_location:

--- a/tasks/cluster_constraint_location.yml
+++ b/tasks/cluster_constraint_location.yml
@@ -3,7 +3,9 @@
   pcs_constraint_location:
     resource: "{{ item.resource }}"
     state: "{{ item.state | default(omit) }}"
-    node_name: "{{ item.node_name }}"
+    node_name: "{{ item.node_name | default(omit) }}"
+    rule: "{{ item.rule | default(omit) }}"
+    constraint_id: "{{ item.constraint_id | default(omit) }}"
     resource1_role: "{{ item.resource1_role | default(omit) }}"
     resource2_role: "{{ item.resource2_role | default(omit) }}"
     score: "{{ item.score | default(omit) }}"


### PR DESCRIPTION
This will make the new option for rule based location constraints in [ondrejhome.pcs-modules-2](https://github.com/OndrejHome/ansible.pcs-modules-2) also available in this role

- needs https://github.com/OndrejHome/ansible.pcs-modules-2/pull/43