### PR TITLE
Set cluster user and group as system

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,11 +86,13 @@
 - name: Create cluster system group
   group:
     name: "{{ cluster_group }}"
+    system: true
     state: 'present'
 
 - name: Create cluster system user
   user:
     name: "{{ cluster_user }}"
+    system: true
     state: 'present'
     password: >-
       {{ cluster_user_pass |


### PR DESCRIPTION
Hi @OndrejHome 

i think the cluster user and group should be marked as system, since they are not used as regular users to log into the system, but just to run the cluster services.

regards,
Michael